### PR TITLE
Adding a dependabot to manage cargo dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo" # 
+    directory: "/" 
+    schedule:
+      interval: "daily"
+      time: "07:20"
+    open-pull-requests-limit: 20

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,5 @@ updates:
     directory: "/" 
     schedule:
       interval: "daily"
-      time: "07:20"
+      time: "13:30"
     open-pull-requests-limit: 20


### PR DESCRIPTION
This pull request adds a [Dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/) configuration file to enable automated dependency updates for the Cargo.

The configuration is set to:
- Check for updates daily.
- Open up to 10 pull requests at a time.

These are the [pull requests](https://github.com/sandptel/rag-api-server/pulls) it created on my fork.